### PR TITLE
Add cross-compilation support for Scala-2.13.0-M5

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,30 +7,30 @@ An independent set of benchmarks for testing common Scala idioms.
 ** Running
 
 To run all benchmarks for the default Scala version (2.12):
-```
-# runs benchmarks according to the rules:
-#   -t 1      <-- one thread
-#   -f 1      <-- one forked JVM
-#   -wi 5     <-- five warmup runs before the actual measuring begins
-#   -i 5      <-- five actual benchmarking iterations
-#   .*Bench.* <-- only files matching `Bench` - which is all of them - are included in the run
-$ sbt "jmh:run -t 1 -f 1 -wi 5 -i 5 .*Bench.*"
-```
+#+BEGIN_SRC shell
+  # runs benchmarks according to the rules:
+  #   -t 1      <-- one thread
+  #   -f 1      <-- one forked JVM
+  #   -wi 5     <-- five warmup runs before the actual measuring begins
+  #   -i 5      <-- five actual benchmarking iterations
+  #   .*Bench.* <-- only files matching `Bench` - which is all of them - are included in the run
+  sbt "jmh:run -t 1 -f 1 -wi 5 -i 5 .*Bench.*"
+#+END_SRC
 
 To run all benchmarks for an alternative Scala version:
-```
-$ sbt "++2.13.0-M5 jmh:run -t 1 -f 1 -wi 5 -i 5 .*Bench.*"
-```
+#+BEGIN_SRC shell
+  sbt "++2.13.0-M5 jmh:run -t 1 -f 1 -wi 5 -i 5 .*Bench.*"
+#+END_SRC
 
 Running all benchmarks can take a long time (i.e. hours). To specify a single `StreamBench` benchmark:
-```
-$ sbt "jmh:run -t 1 -f 1 -wi 5 -i 5 .*StreamBench.*"
-```
+#+BEGIN_SRC shell
+  sbt "jmh:run -t 1 -f 1 -wi 5 -i 5 .*StreamBench.*"
+#+END_SRC
 
 And to do the same for all supported Scala versions:
-```
-$ sbt "+ jmh:run -t 1 -f 1 -wi 5 -i 5 .*StreamBench.*"
-```
+#+BEGIN_SRC shell
+  sbt "+ jmh:run -t 1 -f 1 -wi 5 -i 5 .*StreamBench.*"
+#+END_SRC
 
 ** Results
 

--- a/README.org
+++ b/README.org
@@ -4,6 +4,34 @@
 
 An independent set of benchmarks for testing common Scala idioms.
 
+** Running
+
+To run all benchmarks for the default Scala version (2.12):
+```
+# runs benchmarks according to the rules:
+#   -t 1      <-- one thread
+#   -f 1      <-- one forked JVM
+#   -wi 5     <-- five warmup runs before the actual measuring begins
+#   -i 5      <-- five actual benchmarking iterations
+#   .*Bench.* <-- only files matching `Bench` - which is all of them - are included in the run
+$ sbt "jmh:run -t 1 -f 1 -wi 5 -i 5 .*Bench.*"
+```
+
+To run all benchmarks for an alternative Scala version:
+```
+$ sbt "++2.13.0-M5 jmh:run -t 1 -f 1 -wi 5 -i 5 .*Bench.*"
+```
+
+Running all benchmarks can take a long time (i.e. hours). To specify a single `StreamBench` benchmark:
+```
+$ sbt "jmh:run -t 1 -f 1 -wi 5 -i 5 .*StreamBench.*"
+```
+
+And to do the same for all supported Scala versions:
+```
+$ sbt "+ jmh:run -t 1 -f 1 -wi 5 -i 5 .*StreamBench.*"
+```
+
 ** Results
 
 *** Functional Programming

--- a/build.sbt
+++ b/build.sbt
@@ -2,21 +2,31 @@ name := """scala-benchmarks"""
 
 version := "1.0.0"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.8"
+
+crossScalaVersions := Seq(scalaVersion.value, "2.13.0-M5")
 
 scalacOptions := Seq(
   "-opt:l:inline",
   "-opt-inline-from:**",
   "-deprecation",
-  "-Ypartial-unification",
   "-Ywarn-value-discard",
-  "-Ywarn-unused-import",
+  "-Ywarn-unused:imports",
   "-Ywarn-dead-code",
   "-Ywarn-numeric-widen"
 )
 
+Compile / unmanagedSourceDirectories ++= {
+  val mainSourceDir = baseDirectory.value / "src" / "main" / "scala"
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 13)) =>
+      Seq(file(mainSourceDir.getPath + "-2.13"))
+    case _ => Nil
+  }
+}
+
 libraryDependencies ++= Seq(
-  "org.scalaz" %% "scalaz-core" % "7.2.24"
+  "org.scalaz" %% "scalaz-core" % "7.2.27"
 )
 
 /* To run benchmarks:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.4
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")

--- a/src/main/scala-2.13/benchmarks/package.scala
+++ b/src/main/scala-2.13/benchmarks/package.scala
@@ -1,0 +1,12 @@
+package object benchmarks {
+  // Override references to `Stream` within `package benchmarks` to point to
+  // `s.c.i.LazyList` instead of `s.c.i.Stream` which was deprecated in Scala
+  // 2.13.
+  //
+  // Note that if for some reason this file is not included during compilation
+  // (for example, if sbt fails to include the Scala 2.13-specific source
+  // directory), then the benchmarks will still compile fine, albeit with
+  // warnings that `Stream` is deprecated.
+  type Stream[+A] = scala.collection.immutable.LazyList[A]
+  val Stream = scala.collection.immutable.LazyList
+}

--- a/src/main/scala/benchmarks/StreamBench.scala
+++ b/src/main/scala/benchmarks/StreamBench.scala
@@ -39,7 +39,6 @@ class StreamBench {
     str1 = Stream.range(1, 10000)
     str2 = Stream.range(10000, 1, -1)
     estr1 = EphemeralStream.range(1, 10000)
-    estr2 = EphemeralStream.fromStream(str2)
   }
 
   @Benchmark


### PR DESCRIPTION
Since the first Scala 2.13 Release Candidate is coming soon™ and brings with it the reworked collections library, I thought it would be interesting to add 2.13 as a cross target for this project. 2.12 remains the default.

When running benchmarks compiled with Scala 2.13, the newly introduced `s.c.i.LazyList` will be used instead of the deprecated `s.c.i.Stream`. In order to keep the diff small and avoid code duplication, this is done by simply aliasing `Stream` to `LazyList` for 2.13 builds. This means that the corresponding benchmarks will still be named "stream*".

If there is interest, I was also thinking about adding benchmarks for the new immutable array wrapper `s.c.i.ArraySeq` as well as [`cats.data.Chain`](https://typelevel.org/blog/2018/09/04/chain-replacing-the-list-monoid.html), which advertises O(1) concat, O(1) append, and amortized O(1) uncons.